### PR TITLE
Resolution for issue https://github.com/lelylan/haproxy-mqtt/issues/4

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -33,6 +33,10 @@ listen mqtt
   bind *:1883
   bind *:8883 ssl crt /certs/lelylan-mqtt.pem
   mode tcp
+  #Use this to avoid the connection loss when client subscribed for a topic and its idle for sometime
+  option clitcpka # For TCP keep-alive
+  timeout client 3h #By default TCP keep-alive interval is 2hours in OS kernal, 'cat /proc/sys/net/ipv4/tcp_keepalive_time'
+  timeout server 3h #By default TCP keep-alive interval is 2hours in OS kernal
   option tcplog
   balance leastconn
   server mosca_1 178.62.122.204:1883 check


### PR DESCRIPTION
Added tcp keep-alive and timeout greater than 2 hours so that it wont close the connection before the OS tcp_keepalive_time